### PR TITLE
Conform delete project keys endpoint to REST convention

### DIFF
--- a/parrot-api/api/projects.go
+++ b/parrot-api/api/projects.go
@@ -148,18 +148,13 @@ func deleteProjectKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var data = projectKeyPayload{}
-	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-		handleError(w, err)
+	keyName := chi.URLParam(r, "keyName")
+	if keyName == "" {
+		handleError(w, apiErrors.ErrBadRequest)
 		return
 	}
 
-	if data.Key == "" {
-		handleError(w, apiErrors.ErrUnprocessable)
-		return
-	}
-
-	result, err := store.DeleteProjectKey(projectID, data.Key)
+	result, err := store.DeleteProjectKey(projectID, keyName)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/parrot-api/api/router.go
+++ b/parrot-api/api/router.go
@@ -52,7 +52,7 @@ func NewRouter(ds datastore.Store, tp auth.TokenProvider) http.Handler {
 
 			r2.Post("/keys", mustAuthorize(canUpdateProject, addProjectKey))
 			r2.Patch("/keys", mustAuthorize(canUpdateProject, updateProjectKey))
-			r2.Delete("/keys", mustAuthorize(canUpdateProject, deleteProjectKey))
+			r2.Delete("/keys/:keyName", mustAuthorize(canUpdateProject, deleteProjectKey))
 
 			r2.Route("/users", func(r3 chi.Router) {
 				r3.Get("/", mustAuthorize(canViewProjectRoles, getProjectUsers))

--- a/web-app/src/app/projects/services/projects.service.ts
+++ b/web-app/src/app/projects/services/projects.service.ts
@@ -123,9 +123,8 @@ export class ProjectsService {
 
   deleteProjectKey(projectId: string, key: string): Observable<Project> {
     let request = this.api.request({
-      uri: `/projects/${projectId}/keys`,
-      method: 'DELETE',
-      body: JSON.stringify({ key: key }),
+      uri: `/projects/${projectId}/keys/${key}`,
+      method: 'DELETE'
     })
       .map(res => {
         let payload = res.payload;


### PR DESCRIPTION
The delete project keys endpoint is not using REST idioms. This changes conform it's interface and update the web-app client accordingly.

This resolves #78.