### PR TITLE
Conform patch locale translation endpoint to REST interface

### DIFF
--- a/parrot-api/api/locales.go
+++ b/parrot-api/api/locales.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pressly/chi"
 )
 
+type updateLocalePairsPayload struct {
+	Pairs map[string]string `json:pairs`
+}
+
 // createLocale is an API endpoint for creating a new project locale.
 func createLocale(w http.ResponseWriter, r *http.Request) {
 	projectID := chi.URLParam(r, "projectID")
@@ -115,8 +119,8 @@ func updateLocalePairs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loc := &model.Locale{}
-	if err := json.NewDecoder(r.Body).Decode(&loc.Pairs); err != nil {
+	payload := &updateLocalePairsPayload{}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		handleError(w, apiErrors.ErrUnprocessable)
 		return
 	}
@@ -127,6 +131,7 @@ func updateLocalePairs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	loc := &model.Locale{Pairs: payload.Pairs}
 	loc.SyncKeys(project.Keys)
 
 	result, err := store.UpdateLocalePairs(projectID, ident, loc.Pairs)
@@ -134,6 +139,8 @@ func updateLocalePairs(w http.ResponseWriter, r *http.Request) {
 		handleError(w, err)
 		return
 	}
+
+	result.SyncKeys(project.Keys)
 
 	render.JSON(w, http.StatusOK, result)
 }

--- a/parrot-api/datastore/postgres/locale.go
+++ b/parrot-api/datastore/postgres/locale.go
@@ -36,7 +36,7 @@ func (db *PostgresDB) UpdateLocalePairs(projID string, localeIdent string, pairs
 		return nil, err
 	}
 
-	row := db.QueryRow("UPDATE locales SET pairs = $1 WHERE project_id = $2 AND ident = $3 RETURNING *", values, projID, localeIdent)
+	row := db.QueryRow("UPDATE locales SET pairs = pairs || $1 WHERE project_id = $2 AND ident = $3 RETURNING *", values, projID, localeIdent)
 	loc := model.Locale{}
 	err = row.Scan(&loc.ID, &loc.Ident, &loc.Language, &loc.Country, &h, &loc.ProjectID)
 	if err != nil {
@@ -49,6 +49,7 @@ func (db *PostgresDB) UpdateLocalePairs(projID string, localeIdent string, pairs
 			loc.Pairs[k] = v.String
 		}
 	}
+
 	return &loc, nil
 }
 

--- a/web-app/src/app/locales/model/locale.ts
+++ b/web-app/src/app/locales/model/locale.ts
@@ -3,7 +3,7 @@ export interface Locale {
     ident: string;
     language: string;
     country: string;
-    pairs: Object;
+    pairs: Pair[];
     project_id: string;
 }
 

--- a/web-app/src/app/locales/services/locales.service.ts
+++ b/web-app/src/app/locales/services/locales.service.ts
@@ -6,7 +6,7 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/share';
 
 import { APIService } from './../../shared/api.service';
-import { Locale, LocaleInfo, ExportFormat } from './../model';
+import { Pair, Locale, LocaleInfo, ExportFormat } from './../model';
 import { LocalesList, LocaleExportFormats } from './../../app.constants';
 
 @Injectable()
@@ -60,11 +60,11 @@ export class LocalesService {
         return request;
     }
 
-    updateLocalePairs(projectId: string, localeIdent: string, pairs): Observable<Locale> {
+    updateLocalePairs(projectId: string, localeIdent: string, pairs: Pair[]): Observable<Locale> {
         let request = this.api.request({
             uri: `/projects/${projectId}/locales/${localeIdent}/pairs`,
             method: 'PATCH',
-            body: JSON.stringify(pairs),
+            body: JSON.stringify({'pairs': pairs}),
         })
             .map(res => {
                 let payload = res.payload;


### PR DESCRIPTION
Patch endpoint for locale translations partially updates document, instead of fully replacing translation pairs.

This fixes #73 